### PR TITLE
fix: disable cache

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -33,6 +33,9 @@ default: &default
     api_key: <%= ENV["ETHERPAD_API_KEY"] %>
     api_version: "1.2.1"
   decidim:
+    # NOTE(d1): disable cache again (see ./environments/production.rb for :null_store config)
+    # https://github.com/decidim/decidim/issues/13422#issuecomment-2428763725
+    cache_expiry_time: 0
     maximum_attachment_size: 10
     verifications:
       document_types: <%%= Decidim::Env.new("VERIFICATIONS_DOCUMENT_TYPES", %w(identification_number passport)).to_array %>


### PR DESCRIPTION
This change is specifically to stop the images in emails being 404.

### Context

See https://github.com/decidim/decidim/issues/13422#issuecomment-2428763725

See https://docs.decidim.org/en/develop/configure/environment_variables.html

> Note that zero ("0") is different than an empty string and it will
  disable the cache completely.

See https://github.com/decidim/decidim/blob/51c0700f8a5030a87b51ba883675ad09e5fd3506/decidim-generators/lib/decidim/generators/app_templates/secrets.yml.erb#L36